### PR TITLE
Update submodule to use https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "accelerator-web-ui-template"]
 	path = accelerator-web-ui-template
-	url = git@github.com:snowplow-incubator/accelerator-web-ui-template.git
+	url = https://github.com/snowplow-incubator/accelerator-web-ui-template.git

--- a/README.md
+++ b/README.md
@@ -1,4 +1,27 @@
-# Snowplow Accelerator Template
-This is a template for a Snowplow accelerator. Instructions on set up can be viewed [here](https://docs.snowplow.io/accelerators/template/)
+# Marketing Attribution Accelerator
 
+This accelerator guides the user through setting up Snowplow for Marketing Attribution.
 
+## Installation
+
+Recursively update the git submodules:
+
+```sh
+git submodule update --init --recursive
+```
+
+To build the Hugo app:
+
+```sh
+./scripts/build.sh build
+```
+
+## Usage
+
+To start an HTTP server serving the app, use:
+
+```sh
+./scripts/build.sh serve
+```
+
+This will run `hugo server` on the background.

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,8 +3,8 @@ publish = 'public'
 command = './scripts/build.sh build $BUILD_OUTPUT_PATH'
 [build.environment]
 HUGO_VERSION = '0.104.1'
-HUGO_BASEURL = 'https://docs.snowplow.io/accelerators/{{YOUR BASE URL}}/'
-BUILD_OUTPUT_PATH = '/accelerators/{{YOUR BASE URL}}/'
+HUGO_BASEURL = 'https://docs.snowplow.io/accelerators/marketing-attribution/'
+BUILD_OUTPUT_PATH = '/accelerators/marketing-attribution/'
 
 [context.production]
 [context.production.environment]
@@ -18,6 +18,6 @@ command = './scripts/build.sh build $BUILD_OUTPUT_PATH $DEPLOY_PRIME_URL'
 
 [[redirects]]
 from = "/*"
-to = "/accelerators/{{YOUR BASE URL}}/:splat"
+to = "/accelerators/marketing-attribution/:splat"
 force = true
 status = 301


### PR DESCRIPTION
When we use git@ this uses ssh to clone the submodule but Netlify doesn't like this (because it can't clone it via ssh).