### PR TITLE
Edit base URL

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 title = "Fractribution analysis"
-baseURL = "https://docs.snowplow.io/accelerators/snowplow_fractribution/"
+baseURL = "https://docs.snowplow.io/accelerators/snowplow-fractribution/"
 
 [params]
   description = "Tutorial for running fractional attribution on Snowplow data"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,8 +3,8 @@ publish = 'public'
 command = './scripts/build.sh build $BUILD_OUTPUT_PATH'
 [build.environment]
 HUGO_VERSION = '0.104.1'
-HUGO_BASEURL = 'https://docs.snowplow.io/accelerators/snowplow_fractribution/'
-BUILD_OUTPUT_PATH = '/accelerators/snowplow_fractribution/'
+HUGO_BASEURL = 'https://docs.snowplow.io/accelerators/snowplow-fractribution/'
+BUILD_OUTPUT_PATH = '/accelerators/snowplow-fractribution/'
 
 [context.production]
 [context.production.environment]
@@ -18,6 +18,6 @@ command = './scripts/build.sh build $BUILD_OUTPUT_PATH $DEPLOY_PRIME_URL'
 
 [[redirects]]
 from = "/*"
-to = "/accelerators/snowplow_fractribution/:splat"
+to = "/accelerators/snowplow-fractribution/:splat"
 force = true
 status = 301


### PR DESCRIPTION
Edit base URL to remove '_snowplow' which blocks the rendering of mermaid charts for ublock users.