### PR TITLE
Update info on package version support

### DIFF
--- a/content/modeling/modeling_1.md
+++ b/content/modeling/modeling_1.md
@@ -14,10 +14,10 @@ Please note that this accelerator currently only supports v0.1.0 of the snowplow
 
 ```yml
 packages:
-  - package: snowplow/snowplow_web
-    version: {{<component name="snowplow_web_latest">}}
   - package: snowplow/snowplow_fractribution
     version: 0.1.0
+  - package: snowplow/snowplow_web
+    version: {{<component name="snowplow_web_latest">}}
 ```
 
 ***

--- a/content/modeling/modeling_1.md
+++ b/content/modeling/modeling_1.md
@@ -15,7 +15,7 @@ Please note that this accelerator currently only supports v0.1.0 of the snowplow
 ```yml
 packages:
   - package: snowplow/snowplow_web
-    version: {{ <component name="snowplow_web_latest"}}
+    version: {{ <component name="snowplow_web_latest"> }}
   - package: snowplow/snowplow_fractribution
     version: 0.1.0
 ```

--- a/content/modeling/modeling_1.md
+++ b/content/modeling/modeling_1.md
@@ -6,7 +6,11 @@ post = ""
 
 
 #### **Step 1:** Add snowplow_fractribution package
-Add the snowplow_fractribution package to your packages.yml file. The latest version can be found [here](https://hub.getdbt.com/snowplow/snowplow_fractribution/latest/). You should already have the snowplow_web package present in the packages.yml file.
+Add the snowplow_fractribution package to your packages.yml file. You should already have the snowplow_web package present in the packages.yml file.
+
+{{% notice info %}}
+Please note that this accelerator currently only supports v0.1.0 of the snowplow_fractribution package.
+{{% /notice %}}
 
 ```yml
 packages:

--- a/content/modeling/modeling_1.md
+++ b/content/modeling/modeling_1.md
@@ -15,7 +15,7 @@ Please note that this accelerator currently only supports v0.1.0 of the snowplow
 ```yml
 packages:
   - package: snowplow/snowplow_web
-    version: 0.9.3
+    version: {{ <component name="snowplow_web_latest"}}
   - package: snowplow/snowplow_fractribution
     version: 0.1.0
 ```

--- a/content/modeling/modeling_1.md
+++ b/content/modeling/modeling_1.md
@@ -15,7 +15,7 @@ Please note that this accelerator currently only supports v0.1.0 of the snowplow
 ```yml
 packages:
   - package: snowplow/snowplow_web
-    version: {{ <component name="snowplow_web_latest"> }}
+    version: {{<component name="snowplow_web_latest">}}
   - package: snowplow/snowplow_fractribution
     version: 0.1.0
 ```

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -19,6 +19,7 @@ mkdir build/themes
 cp -R accelerator-web-ui-template/themes/hugo-theme-learn build/themes/
 cp -R accelerator-web-ui-template/layouts build/
 cp -R accelerator-web-ui-template/static build/
+cp -R accelerator-web-ui-template/data build/
 cd build
 
 echo "Creating Hugo site..."


### PR DESCRIPTION
This change is about letting users know that the accelerator only supports v0.1.0 of the dbt package.